### PR TITLE
Add empty "ignore" to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "1.2.2",
   "description": "Drag and drop so simple it hurts",
   "main": "dist/dragula.js",
+  "ignore": [],
   "homepage": "https://github.com/bevacqua/dragula",
   "authors": [
     "Nicolas Bevacqua <nicolasbevacqua@gmail.com>"


### PR DESCRIPTION
Gets rid of this "invalid-meta" warning:

![invalid meta](https://dl.dropboxusercontent.com/spa/ibxdnt7kjmsxult/36kwp002.png)

See https://github.com/bower/bower/issues/1388