### PR TITLE
Fixes the example so an empty container stays visible.

### DIFF
--- a/example/example.css
+++ b/example/example.css
@@ -108,6 +108,7 @@ button:hover {
 .container {
   display: table-cell;
   background-color: rgba(255, 255, 255, 0.2);
+  width: 50%;
 }
 .container:nth-child(odd) {
   background-color: rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Hi @bevacqua 

I love the motivation for this library. I'm sure I'll be using it in the future.

In the example, I did notice when a container becomes empty, it's no longer visible. I just added a width to the containers in example.css.