### PR TITLE
improve pre, code style

### DIFF
--- a/example/example.css
+++ b/example/example.css
@@ -38,9 +38,14 @@ a:hover {
   color: #ecf0f1;
 }
 
+pre {
+  white-space: pre-wrap;
+}
+
 pre code {
   color: #fff;
-  font-size: 18px;
+  font-size: 14px;
+  line-height: 1.3;
 }
 
 label {


### PR DESCRIPTION
Added some css lines to avoid the body horizontal scroll and `pre` overflow.
![screen](https://cloud.githubusercontent.com/assets/784056/7599277/eb462b0e-f900-11e4-83d4-6d3295caa6fc.png)
