### PR TITLE
Improve shadow position when revertOnSpill === true

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -272,10 +272,14 @@ function dragula (initialContainers, options) {
     }
     var item = _copy || _item;
     var immediate = getImmediateChild(dropTarget, elementBehindCursor);
-    if (immediate === null) {
+    if (immediate !== null) {
+      var reference = getReference(dropTarget, immediate, clientX, clientY);
+    } else if (o.revertOnSpill === true) {
+      var reference = _initialSibling;
+      dropTarget = _source;
+    } else {
       return;
     }
-    var reference = getReference(dropTarget, immediate, clientX, clientY);
     if (reference === null || reference !== item && reference !== nextEl(item)) {
       _currentSibling = reference;
       dropTarget.insertBefore(item, reference);


### PR DESCRIPTION
When `revertOnSpill === true` this changes the shadow position to reflect the reversion, when applicable (user drags outside contianer). This should close #49.

Let me know if there are any changes you'd like me to make. I tried to keep with your existing style of not using many blank lines to separate statements.

While I'm at it, it might be worthwhile to do an equivalent change for the `removeOnSpill` option. I can also do that as a separate issue and pull request, if desired.