### PR TITLE
Improve shadow behaviour

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -275,11 +275,11 @@ function dragula (initialContainers, options) {
     var immediate = getImmediateChild(dropTarget, elementBehindCursor);
     if (immediate !== null) {
       reference = getReference(dropTarget, immediate, clientX, clientY);
-    } else if (o.revertOnSpill === true) {
+    } else if (o.revertOnSpill === true && !o.copy) {
       reference = _initialSibling;
       dropTarget = _source;
     } else {
-      if (o.removeOnSpill === true && item.parentElement !== null) {
+      if ((o.copy || o.removeOnSpill === true) && item.parentElement !== null) {
         item.parentElement.removeChild(item);
       }
       return;

--- a/dragula.js
+++ b/dragula.js
@@ -279,6 +279,9 @@ function dragula (initialContainers, options) {
       reference = _initialSibling;
       dropTarget = _source;
     } else {
+      if (o.removeOnSpill === true && item.parentElement !== null) {
+        item.parentElement.removeChild(item);
+      }
       return;
     }
     if (reference === null || reference !== item && reference !== nextEl(item)) {


### PR DESCRIPTION
When `removeOnSpill` is set to `true`, dragging an item outside of its drop destination now removes the shadow. This gives a clearer indication to the user as to what will happen when they release the drag.

As an addendum, the second commit also fixes my previous pull request (#64). I didn't test using both `revertOnSpill` and `copy` at the same time, which resulted in inconsistent shadow behaviour. I've included both in this PR because the bugfix requires most of the same code.