### PR TITLE
Differentiate between drag and click events

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -15,6 +15,7 @@ function dragula (initialContainers, options) {
   var _currentSibling; // reference sibling now
   var _copy; // item used for copying
   var _containers = []; // containers managed by the drake
+  var _timerClick; // timer for setTimeout renderMirrorImage
 
   var o = options || {};
   if (o.moves === void 0) { o.moves = always; }
@@ -85,7 +86,7 @@ function dragula (initialContainers, options) {
     _offsetY = getCoord('pageY', e) - offset.top;
 
     // delay renderMirrorImage to fire click event when mouseup quickly (defaluts 100ms).
-    setTimeout(function(){
+    _timerClick = setTimeout(function(){
       renderMirrorImage();
       drag(e);
     }, o.delay);
@@ -152,6 +153,11 @@ function dragula (initialContainers, options) {
   }
 
   function release (e) {
+
+    if ( _timerClick ){
+      clearTimeout(_timerClick);
+    }
+
     if (!api.dragging) {
       return;
     }

--- a/dragula.js
+++ b/dragula.js
@@ -23,6 +23,7 @@ function dragula (initialContainers, options) {
   if (o.revertOnSpill === void 0) { o.revertOnSpill = false; }
   if (o.removeOnSpill === void 0) { o.removeOnSpill = false; }
   if (o.direction === void 0) { o.direction = 'vertical'; }
+  if (o.delay === void 0) { o.delay = 100; }
 
   var api = emitter({
     addContainer: manipulateContainers('add'),
@@ -82,8 +83,13 @@ function dragula (initialContainers, options) {
     var offset = getOffset(_item);
     _offsetX = getCoord('pageX', e) - offset.left;
     _offsetY = getCoord('pageY', e) - offset.top;
-    renderMirrorImage();
-    drag(e);
+
+    // delay renderMirrorImage to fire click event when mouseup quickly (defaluts 100ms).
+    setTimeout(function(){
+      renderMirrorImage();
+      drag(e);
+    }, o.delay);
+
     e.preventDefault();
   }
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -64,6 +64,7 @@ dragula(containers, {
   copy: false,           // elements are moved by default, not copied
   revertOnSpill: false,  // spilling will put the element back where it was dragged from, if this is true
   removeOnSpill: false   // spilling will `.remove` the element, if this is true
+  delay: 100             // delay renderMirrorImage to fire click event when mouseup quickly (defaluts 100ms).
 });
 ```
 


### PR DESCRIPTION
delay renderMirrorImage to fire click event when mouseup quickly
(defaluts 100ms).

I npm build fail. so dist/dragula.js is old file, you need to npm build