### PR TITLE
Don't add gu-transit class until after delay.

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -106,6 +106,7 @@ function dragula (initialContainers, options) {
   }
 
   function renderMirrorAndDrag () {
+    addClass(_copy || _item, 'gu-transit');
     renderMirrorImage();
     drag();
   }
@@ -143,10 +144,7 @@ function dragula (initialContainers, options) {
 
     if (o.copy) {
       _copy = item.cloneNode(true);
-      addClass(_copy, 'gu-transit');
       api.emit('cloned', _copy, item);
-    } else {
-      addClass(item, 'gu-transit');
     }
 
     _source = container;


### PR DESCRIPTION
The gu-transit class is currently being added on start before the delay. This causes the element to flicker when a user is only clicking on the element. The gu-transit class should only be added when the element is actually in transit.