### PR TITLE
Fixes #130 - delay: true does not work on android chrome

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -104,7 +104,7 @@ function dragula (initialContainers, options) {
     } else {
       renderMirrorAndDrag();
     }
-    e.preventDefault();
+    cancelEvent(e);
   }
 
   function renderMirrorAndDrag () {
@@ -294,6 +294,7 @@ function dragula (initialContainers, options) {
     if (e) {
       _clientX = getCoord('clientX', e);
       _clientY = getCoord('clientY', e);
+      cancelEvent(e);
     }
     var x = _clientX - _offsetX;
     var y = _clientY - _offsetY;
@@ -404,6 +405,12 @@ function dragula (initialContainers, options) {
 
     function resolve (after) {
       return after ? nextEl(target) : target;
+    }
+  }
+
+  function cancelEvent(e) {
+    if (e.type === 'mousedown' || e.type === 'touchmove') {
+      e.preventDefault();
     }
   }
 }


### PR DESCRIPTION
Fixes #130.

On desktop, we want to cancel mousedown, so the user doesn’t start
scrolling the window or highlighting text while moving their mouse
around.

On mobile, if we cancel touchstart, the subsequent click event doesn’t
fire.  In that case, we don’t want to cancel touchstart, but instead
cancel touchmove.