### PR TITLE
add projecttalk link

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,7 @@
 [![logo.png][3]][2]
 
-[![Travis CI][5]][4] [![Flattr][6]][7]
+[![Travis CI][5]][4] [![Flattr][6]][7] [![ProjectTalk](http://www.projecttalk.io/images/gh_badge-3e578a9f437f841de7446bab9a49d103.svg?vsn=d)]
+(http://www.projecttalk.io/boards/bevacqua%2Fdragula?utm_campaign=gh-badge&utm_medium=badge&utm_source=github)
 
 > Drag and drop so simple it hurts
 


### PR DESCRIPTION
this adds a badge-link to the projecttalk messageboard for dragula. this way, users have a place to help each others outside of the github issues.