### PR TITLE
Add Node.js v4 stable to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - 'iojs'
+  - '4'
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
NodeJS v4 was just released [NodeJS v4 announcement](https://nodejs.org/en/blog/release/v4.0.0/). This updates the CI build script to accommodate the release. Note: It should be "4", not "4.0" since Node will surely get a lot of minor updates before it goes LTS and this repo should test on the latest of them.