### PR TITLE
add copySortSource

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -35,6 +35,7 @@ function dragula (initialContainers, options) {
   if (o.removeOnSpill === void 0) { o.removeOnSpill = false; }
   if (o.direction === void 0) { o.direction = 'vertical'; }
   if (o.mirrorContainer === void 0) { o.mirrorContainer = body; }
+  if (o.copySortSource === void 0) { o.copySortSource = false; }
 
   var drake = emitter({
     containers: o.containers,
@@ -208,7 +209,7 @@ function dragula (initialContainers, options) {
     var clientY = getCoord('clientY', e);
     var elementBehindCursor = getElementBehindPoint(_mirror, clientX, clientY);
     var dropTarget = findDropTarget(elementBehindCursor, clientX, clientY);
-    if (dropTarget && (!_copy || dropTarget !== _source)) {
+    if (dropTarget && ((_copy && o.copySortSource) || (!_copy || dropTarget !== _source))) {
       drop(item, dropTarget);
     } else if (o.removeOnSpill) {
       remove();
@@ -218,6 +219,10 @@ function dragula (initialContainers, options) {
   }
 
   function drop (item, target) {
+    var parent = item.parentElement;
+    if (_copy && o.copySortSource && target === _source) {
+      parent.removeChild(_item);
+    }
     if (isInitialPlacement(target)) {
       drake.emit('cancel', item, _source);
     } else {
@@ -335,7 +340,7 @@ function dragula (initialContainers, options) {
       _lastDropTarget = dropTarget;
       over();
     }
-    if (dropTarget === _source && _copy) {
+    if (dropTarget === _source && _copy && !o.copySortSource) {
       if (item.parentElement) {
         item.parentElement.removeChild(item);
       }

--- a/readme.markdown
+++ b/readme.markdown
@@ -165,6 +165,13 @@ copy: function (el, source) {
   return el.className === 'you-may-copy-us';
 }
 ```
+#### `options.copySortSource`
+
+If `copy` is set to `true` _(or a method that returns `true`)_ and `copySortSource` to true as well, item will be allowed to moved _(reordered)_ in same container.
+
+```js
+copy: true,
+copySortSource: true
 
 #### `options.revertOnSpill`
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -172,6 +172,7 @@ If `copy` is set to `true` _(or a method that returns `true`)_ and `copySortSour
 ```js
 copy: true,
 copySortSource: true
+```
 
 #### `options.revertOnSpill`
 


### PR DESCRIPTION
PR for [#74](https://github.com/bevacqua/dragula/issues/74)

This features allow to move the copyable div in same container to reorder its position if copySortSource option is set to true.