### PR TITLE
Fixs simultaneous click and mousemove events fire

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -17,6 +17,8 @@ function dragula (initialContainers, options) {
   var _item; // item being dragged
   var _offsetX; // reference x
   var _offsetY; // reference y
+  var _moveX; // reference move x
+  var _moveY; // reference move y
   var _initialSibling; // reference sibling when grabbed
   var _currentSibling; // reference sibling now
   var _copy; // item used for copying
@@ -63,6 +65,7 @@ function dragula (initialContainers, options) {
     var op = remove ? 'remove' : 'add';
     touchy(documentElement, op, 'mousedown', grab);
     touchy(documentElement, op, 'mouseup', release);
+    touchy(documentElement, op, 'mousemove', startBecauseMouseMoved);
   }
 
   function eventualMovements (remove) {
@@ -88,6 +91,9 @@ function dragula (initialContainers, options) {
   }
 
   function grab (e) {
+    _moveX = e.clientX;
+    _moveY = e.clientY;
+
     var ignore = (e.which !== 0 && e.which !== 1) || e.metaKey || e.ctrlKey;
     if (ignore) {
       return; // we only care about honest-to-god left clicks and touch events
@@ -108,6 +114,14 @@ function dragula (initialContainers, options) {
   }
 
   function startBecauseMouseMoved (e) {
+    if (!_grabbed) {
+      return;
+    }
+
+    if (e.clientX === _moveX && e.clientY === _moveY) {
+      return;
+    }
+
     var grabbed = _grabbed; // call to end() unsets _grabbed
     eventualMovements(true);
     movements();


### PR DESCRIPTION
This is a fix to what is described here: http://stackoverflow.com/questions/14538743/what-to-do-if-mousemove-and-click-events-fire-simultaneously and here: https://code.google.com/p/chromium/issues/detail?id=161464

I have windows 10 Chrome 45.0.2454.85 m (64-bit) and the onClick don't works on it. So for example here http://bevacqua.github.io/dragula/  the first example that has "(You can still click on links, as usual!)" don't works when I click on any link (and any other example with links)