### PR TITLE
Fix Drags Getting Ignored on iOS

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -94,7 +94,8 @@ function dragula (initialContainers, options) {
     _moveX = e.clientX;
     _moveY = e.clientY;
 
-    var ignore = whichMouseButton(e) !== 1 || e.metaKey || e.ctrlKey;
+    var whichMouse = whichMouseButton(e);
+    var ignore = (whichMouse != 0 && whichMouse !== 1) || e.metaKey || e.ctrlKey;
     if (ignore) {
       return; // we only care about honest-to-god left clicks and touch events
     }
@@ -118,11 +119,7 @@ function dragula (initialContainers, options) {
     if (!_grabbed) {
       return;
     }
-    if (whichMouseButton(e) === 0) {
-      release({});
-      return; // when text is selected on an input and then dragged, mouseup doesn't fire. this is our only hope
-    }
-    if (e.clientX === _moveX && e.clientY === _moveY) {
+    if (_moveX && _moveY && e.clientX === _moveX && e.clientY === _moveY) {
       return;
     }
     if (o.ignoreInputTextSelection) {

--- a/dragula.js
+++ b/dragula.js
@@ -94,8 +94,8 @@ function dragula (initialContainers, options) {
     _moveX = e.clientX;
     _moveY = e.clientY;
 
-    var whichMouse = whichMouseButton(e);
-    var ignore = (whichMouse !== 0 && whichMouse !== 1) || e.metaKey || e.ctrlKey;
+    var button = whichMouseButton(e);
+    var ignore = (button !== 0 && e.type !== 'mousedown') || button !== 1 || e.metaKey || e.ctrlKey;
     if (ignore) {
       return; // we only care about honest-to-god left clicks and touch events
     }

--- a/dragula.js
+++ b/dragula.js
@@ -95,7 +95,7 @@ function dragula (initialContainers, options) {
     _moveY = e.clientY;
 
     var whichMouse = whichMouseButton(e);
-    var ignore = (whichMouse != 0 && whichMouse !== 1) || e.metaKey || e.ctrlKey;
+    var ignore = (whichMouse !== 0 && whichMouse !== 1) || e.metaKey || e.ctrlKey;
     if (ignore) {
       return; // we only care about honest-to-god left clicks and touch events
     }

--- a/dragula.js
+++ b/dragula.js
@@ -95,7 +95,7 @@ function dragula (initialContainers, options) {
     _moveY = e.clientY;
 
     var button = whichMouseButton(e);
-    var ignore = (button !== 0 && e.type !== 'mousedown') || button !== 1 || e.metaKey || e.ctrlKey;
+    var ignore = (e.type !== 'mousedown' ? button !== 0 : button !== 1) || e.metaKey || e.ctrlKey;
     if (ignore) {
       return; // we only care about honest-to-god left clicks and touch events
     }


### PR DESCRIPTION
Had to check the _moveX and _moveY variables for undefined before
giving up on the drag. Also, touch events’ MouseEvent.which appears to
always be zero, which causes all drags to be ignored. I realize this is
affecting some text-selection fixes, but they completely break touch
support. I expect this to need some tweaking.