### PR TITLE
Replace usage of parentElement with parentNode

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -158,16 +158,16 @@ function dragula (initialContainers, options) {
       return; // don't drag container itself
     }
     var handle = item;
-    while (item.parentElement && isContainer(item.parentElement) === false) {
+    while (item.parentNode && isContainer(item.parentNode) === false) {
       if (o.invalid(item, handle)) {
         return;
       }
-      item = item.parentElement; // drag target should be a top element
+      item = item.parentNode; // drag target should be a top element
       if (!item) {
         return;
       }
     }
-    var source = item.parentElement;
+    var source = item.parentNode;
     if (!source) {
       return;
     }
@@ -216,7 +216,7 @@ function dragula (initialContainers, options) {
       return;
     }
     var item = _copy || _item;
-    drop(item, item.parentElement);
+    drop(item, item.parentNode);
   }
 
   function ungrab () {
@@ -246,7 +246,7 @@ function dragula (initialContainers, options) {
   }
 
   function drop (item, target) {
-    var parent = item.parentElement;
+    var parent = item.parentNode;
     if (_copy && o.copySortSource && target === _source) {
       parent.removeChild(_item);
     }
@@ -263,7 +263,7 @@ function dragula (initialContainers, options) {
       return;
     }
     var item = _copy || _item;
-    var parent = item.parentElement;
+    var parent = item.parentNode;
     if (parent) {
       parent.removeChild(item);
     }
@@ -277,7 +277,7 @@ function dragula (initialContainers, options) {
     }
     var reverts = arguments.length > 0 ? revert : o.revertOnSpill;
     var item = _copy || _item;
-    var parent = item.parentElement;
+    var parent = item.parentNode;
     if (parent === _source && _copy) {
       parent.removeChild(_copy);
     }
@@ -326,7 +326,7 @@ function dragula (initialContainers, options) {
   function findDropTarget (elementBehindCursor, clientX, clientY) {
     var target = elementBehindCursor;
     while (target && !accepted()) {
-      target = target.parentElement;
+      target = target.parentNode;
     }
     return target;
 
@@ -370,8 +370,8 @@ function dragula (initialContainers, options) {
       over();
     }
     if (dropTarget === _source && _copy && !o.copySortSource) {
-      if (item.parentElement) {
-        item.parentElement.removeChild(item);
+      if (item.parentNode) {
+        item.parentNode.removeChild(item);
       }
       return;
     }
@@ -383,8 +383,8 @@ function dragula (initialContainers, options) {
       reference = _initialSibling;
       dropTarget = _source;
     } else {
-      if (_copy && item.parentElement) {
-        item.parentElement.removeChild(item);
+      if (_copy && item.parentNode) {
+        item.parentNode.removeChild(item);
       }
       return;
     }
@@ -431,15 +431,15 @@ function dragula (initialContainers, options) {
     if (_mirror) {
       classes.rm(o.mirrorContainer, 'gu-unselectable');
       touchy(documentElement, 'remove', 'mousemove', drag);
-      _mirror.parentElement.removeChild(_mirror);
+      _mirror.parentNode.removeChild(_mirror);
       _mirror = null;
     }
   }
 
   function getImmediateChild (dropTarget, target) {
     var immediate = target;
-    while (immediate !== dropTarget && immediate.parentElement !== dropTarget) {
-      immediate = immediate.parentElement;
+    while (immediate !== dropTarget && immediate.parentNode !== dropTarget) {
+      immediate = immediate.parentNode;
     }
     if (immediate === documentElement) {
       return null;


### PR DESCRIPTION
This fixes an issue where `target.parentElement` will be `undefined` in
IE11 when `target` is an svg, ultimately resulting in a thrown exception.

Fixes https://github.com/bevacqua/dragula/issues/251.