### PR TITLE
Fixes body reference error

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -13,6 +13,8 @@ function dragula (initialContainers, options) {
     options = initialContainers;
     initialContainers = [];
   }
+  !body && (body = doc.body);
+
   var _mirror; // mirror image
   var _source; // source container
   var _item; // item being dragged

--- a/dragula.js
+++ b/dragula.js
@@ -13,7 +13,7 @@ function dragula (initialContainers, options) {
     options = initialContainers;
     initialContainers = [];
   }
-  !body && (body = doc.body);
+  if (!body) { body = doc.body; }
 
   var _mirror; // mirror image
   var _source; // source container


### PR DESCRIPTION
When dragula is included in the header, the body variable in the closure can't have body reference
due to DOM haven't constructed yet.
To solve that issue, should check body and assign if not.

I made simple demo to check out that :
- appendChild error due to the body is null : 
  https://output.jsbin.com/juramebimo/1

- works fine, because body referes document.body :
  https://output.jsbin.com/vadeweyive/1

#262 issue occurs because dragula was included in the header.