### PR TITLE
Treat contenteditable elements as inputs

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -547,7 +547,7 @@ function always () { return true; }
 function getRectWidth (rect) { return rect.width || (rect.right - rect.left); }
 function getRectHeight (rect) { return rect.height || (rect.bottom - rect.top); }
 function getParent (el) { return el.parentNode === doc ? null : el.parentNode; }
-function isInput (el) { return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT'; }
+function isInput (el) { return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.contentEditable === 'true'; }
 
 function nextEl (el) {
   return el.nextElementSibling || manually();


### PR DESCRIPTION
Currently a contenteditable element within something draggable is unusable (unless you right click to position the caret first).