### PR TITLE
Allows dragula to work with Aurelia's bound arrays

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -201,7 +201,8 @@ function dragula (initialContainers, options) {
 
     _source = context.source;
     _item = context.item;
-    _initialSibling = _currentSibling = nextEl(context.item);
+    _initialSibling = context.item.nextSibling;
+    _currentSibling = nextEl(context.item);
 
     drake.dragging = true;
     drake.emit('drag', _item, _source);

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -106,3 +106,19 @@ test('when dragging a copy and cancel gets called, revert is executed', function
     t.equal(container, div, 'cancel was invoked with container');
   }
 });
+
+test('when dragging and cancel gets called, item is returned to original position, including comment nodes', function (t) {
+  var div = document.createElement('div');
+  var item = document.createElement('div');
+  var siblingComment = document.createComment('</view>');
+  var drake = dragula([div]);
+  div.appendChild(item);
+  div.appendChild(siblingComment);
+  document.body.appendChild(div);
+  drake.start(item);
+  drake.cancel();
+  t.equal(div.children.length, 2, 'nothing happens');
+  t.equal(item.nextSibling, siblingComment);
+  t.equal(drake.dragging, false, 'drake has stopped dragging');
+  t.end();
+});


### PR DESCRIPTION
Aurelia uses some key comment markers to display views in a dynamic list.  Because the framework renders the views bound to the array of viewmodels, rather than allow dragula to manipulate the DOM itself, we cancel the drag event and use the meta data to move the viewmodels in javascript.

But as Aurelia handles the displaying of the views, it adds some comment nodes to the DOM to help itself render correctly.  This change is to keep the item in the same place relative to the comment nodes on `drake.cancel()`