### PR TITLE
added grid layout option

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -450,6 +450,7 @@ function dragula (initialContainers, options) {
 
   function getReference (dropTarget, target, x, y) {
     var horizontal = o.direction === 'horizontal';
+    var grid = o.direction === 'grid';
     var reference = target !== dropTarget ? inside() : outside();
     return reference;
 
@@ -469,6 +470,19 @@ function dragula (initialContainers, options) {
 
     function inside () { // faster, but only available if dropped inside a child element
       var rect = target.getBoundingClientRect();
+      if (grid) {
+        // we need to figure out which edge we're closest to:
+        // top edge: return nextEl(target)
+        // left edge: return nextEl(target)
+        // bottom edge: return target
+        // right edge: return target
+        var distToTop = y - rect.top;
+        var distToLeft = x - rect.left;
+        var distToBottom = rect.bottom - y;
+        var distToRight = rect.right - x;
+        var minDist = Math.min(distToLeft, distToRight, distToTop, distToBottom);
+        return resolve(distToLeft == minDist || distToTop == minDist);
+      }
       if (horizontal) {
         return resolve(x > rect.left + getRectWidth(rect) / 2);
       }

--- a/dragula.js
+++ b/dragula.js
@@ -481,7 +481,7 @@ function dragula (initialContainers, options) {
         var distToBottom = rect.bottom - y;
         var distToRight = rect.right - x;
         var minDist = Math.min(distToLeft, distToRight, distToTop, distToBottom);
-        return resolve(distToLeft == minDist || distToTop == minDist);
+        return resolve(distToLeft === minDist || distToTop === minDist);
       }
       if (horizontal) {
         return resolve(x > rect.left + getRectWidth(rect) / 2);

--- a/readme.markdown
+++ b/readme.markdown
@@ -198,7 +198,7 @@ By default, spilling an element outside of any containers will move the element 
 
 #### `options.direction`
 
-When an element is dropped onto a container, it'll be placed near the point where the mouse was released. If the `direction` is `'vertical'`, the default value, the Y axis will be considered. Otherwise, if the `direction` is `'horizontal'`, the X axis will be considered.
+When an element is dropped onto a container, it'll be placed near the point where the mouse was released. If the `direction` is `'vertical'`, the default value, the Y axis will be considered. Otherwise, if the `direction` is `'horizontal'`, the X axis will be considered. Finally, if the `direction` is `'grid'`, both X and Y axis will be considered.
 
 #### `options.invalid`
 


### PR DESCRIPTION
Neither "horizontal" nor "vertical" work well when dealing with a grid layout of draggable entities. This change adds support for a `direction: 'grid'` option, which handles grid layouts rather well. A dragged element will take the place of another element as soon as the mouse enters it.