### PR TITLE
Fixes error in Firefox when coordinate is not available for elementFromPoint

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -594,6 +594,10 @@ function getCoord (coord, e) {
   if (coord in missMap && !(coord in host) && missMap[coord] in host) {
     coord = missMap[coord];
   }
+  // undefined argument to doc.elementFromPoint throws an error in Firefox, interpreted as 0 in Chrome
+  if (host[coord] === undefined) {
+    return 0;
+  }
   return host[coord];
 }
 


### PR DESCRIPTION
Test 43 succeeds in Chrome but fails in Firefox, due to a call to `doc.elementFromPoint` where the arguments are `undefined`. In Firefox, an error is thrown when `undefined` is passed as an argument to `elementFromPoint`, but in Chrome it is treated as a 0. This change causes `getCoord` to return 0 when it would otherwise return `undefined`.