### PR TITLE
don't clone "checked" attribute of radio inputs

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -195,7 +195,7 @@ function dragula (initialContainers, options) {
 
   function start (context) {
     if (isCopy(context.item, context.source)) {
-      _copy = context.item.cloneNode(true);
+      _copy = cloneNodeWithoutCheckedRadios(context.item);
       drake.emit('cloned', _copy, context.item, 'copy');
     }
 
@@ -417,7 +417,7 @@ function dragula (initialContainers, options) {
       return;
     }
     var rect = _item.getBoundingClientRect();
-    _mirror = _item.cloneNode(true);
+    _mirror = cloneNodeWithoutCheckedRadios(_item);
     _mirror.style.width = getRectWidth(rect) + 'px';
     _mirror.style.height = getRectHeight(rect) + 'px';
     classes.rm(_mirror, 'gu-transit');
@@ -596,6 +596,20 @@ function getCoord (coord, e) {
     coord = missMap[coord];
   }
   return host[coord];
+}
+
+// Runs cloneNode, but removes any `checked` attribuets on radio inputs.
+// https://github.com/bevacqua/dragula/issues/80
+function cloneNodeWithoutCheckedRadios (el) {
+  var mirror = el.cloneNode(true);
+  var mirrorInputs = mirror.getElementsByTagName('input');
+  var len = mirrorInputs.length;
+
+  for (var i = 0; i < len; i++) {
+    if (mirrorInputs[i].type === 'radio') { mirrorInputs[i].checked = false; }
+  }
+
+  return mirror;
 }
 
 module.exports = dragula;

--- a/test/drag.js
+++ b/test/drag.js
@@ -180,6 +180,25 @@ test('when dragging, element gets a mirror image for show', function (t) {
   }
 });
 
+// https://github.com/bevacqua/dragula/issues/80
+test('when dragging, source radio inputs retain their checked attribute', function (t) {
+  var div = document.createElement('div');
+  var item = document.createElement('div');
+  var drake = dragula([div]);
+  item.innerHTML = '<em><input type=radio name=foo checked /></em>';
+  div.appendChild(item);
+  document.body.appendChild(div);
+  drake.on('cloned', cloned);
+  events.raise(item, 'mousedown', { which: 1 });
+  events.raise(item, 'mousemove', { which: 1 });
+  t.plan(4);
+  t.end();
+  function cloned (mirror) {
+    t.equal(item.getElementsByTagName('input')[0].checked, true, 'source radio is still checked');
+    t.equal(mirror.getElementsByTagName('input')[0].checked, false, 'mirror radio is not checked');
+  }
+});
+
 test('when dragging, mirror element gets appended to configured mirrorContainer', function (t) {
   var mirrorContainer = document.createElement('div');
   var div = document.createElement('div');


### PR DESCRIPTION
groups of radio inputs with the same `name` can only have one input
selected. this is a workaround to ensure that dragula can still be used
with elements that contain radio buttons.

fixes https://github.com/bevacqua/dragula/issues/80