### PR TITLE
Update Handle

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -21,7 +21,7 @@ dragula([$('left-events'), $('right-events')])
 dragula([$('left-rollbacks'), $('right-rollbacks')], { revertOnSpill: true });
 dragula([$('left-lovehandles'), $('right-lovehandles')], {
   moves: function (el, container, handle) {
-    return handle.className === 'handle';
+    return handle.classList.contains('handle');
   }
 });
 


### PR DESCRIPTION
In reality we usually may use other classes with 'handle' classes. So it is better to compare with contains than equal.