### PR TITLE
cancel: Check if parent is truthy; fixes #348

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -281,7 +281,9 @@ function dragula (initialContainers, options) {
     var initial = isInitialPlacement(parent);
     if (initial === false && reverts) {
       if (_copy) {
-        parent.removeChild(_copy);
+        if (parent) {
+          parent.removeChild(_copy);
+        }
       } else {
         _source.insertBefore(item, _initialSibling);
       }


### PR DESCRIPTION
As per described in #348, when dealing with elements with both `copy:true` and
`revertOnSpill:true`, parent is not normally defined and was throwing
when called with `removeChild`.