### PR TITLE
Replace testling with tape-run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
 node_js:
   - '4'
-env:
-  - CXX=g++-4.8
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
-before_script:
-  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+      - xvfb
+install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  - npm install

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "styles": "stylus dragula.styl --import node_modules/nib -o dist && cleancss dist/dragula.css -o dist/dragula.min.css",
     "sync": "git checkout gh-pages ; git merge master ; git push ; git checkout master",
     "lint": "jshint . --reporter node_modules/jshint-stylish/index.js",
-    "test": "npm run lint && browserify test/*.js | testling",
+    "test": "npm run lint && browserify test/*.js | tape-run",
     "test-watch": "hihat test/*.js -p tap-dev-tool"
   },
   "repository": {
@@ -45,7 +45,7 @@
     "stylus": "0.52.0",
     "tap-dev-tool": "1.3.0",
     "tape": "4.0.1",
-    "testling": "1.7.1",
+    "tape-run": "^2.1.3",
     "uglify-js": "2.4.24",
     "watchify": "3.3.0"
   }


### PR DESCRIPTION
Replace testling with tape-run, which is an alternative tape test runner that defaults to Electron, but can be configured to use whatever browser desired as well.

Submitting this PR because testling has been frequently leaving zombie processes around for me, and after some time just hangs and becomes unresponsive. testling as a project also appears to be abandoned. I'm not entirely sure of the .travis.yml changes; just going by the tape-run README.

Note: this won't actually fix the existing failing tests, though I can say @cinaglia and I are looking into this.