### PR TITLE
Adds the 'allowNestedContainers' option

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -39,6 +39,7 @@ function dragula (initialContainers, options) {
   if (o.direction === void 0) { o.direction = 'vertical'; }
   if (o.ignoreInputTextSelection === void 0) { o.ignoreInputTextSelection = true; }
   if (o.mirrorContainer === void 0) { o.mirrorContainer = doc.body; }
+  if (o.allowNestedContainers === void 0) { o.allowNestedContainers = false; }
 
   var drake = emitter({
     containers: o.containers,
@@ -154,7 +155,7 @@ function dragula (initialContainers, options) {
     if (drake.dragging && _mirror) {
       return;
     }
-    if (isContainer(item)) {
+    if (isContainer(item) && !o.allowNestedContainers) {
       return; // don't drag container itself
     }
     var handle = item;

--- a/readme.markdown
+++ b/readme.markdown
@@ -108,6 +108,7 @@ dragula(containers, {
   removeOnSpill: false,              // spilling will `.remove` the element, if this is true
   mirrorContainer: document.body,    // set the element that gets mirror elements appended
   ignoreInputTextSelection: true     // allows users to select input text, see details below
+  allowNestedContainers: false       // allows dragging of containers, as in the case of nesting
 });
 ```
 
@@ -230,6 +231,11 @@ The DOM element where the mirror element displayed while dragging will be append
 When this option is enabled, if the user clicks on an input element the drag won't start until their mouse pointer exits the input. This translates into the user being able to select text in inputs contained inside draggable elements, and still drag the element by moving their mouse outside of the input -- so you get the best of both worlds.
 
 This option is enabled by default. Turn it off by setting it to `false`. If its disabled your users won't be able to select text in inputs within `dragula` containers with their mouse.
+
+#### `options.allowNestedContainers`
+
+In some cases nested containers might be required, which will enable dragging not only between containers but dragging of containers themselves. In such cases addional logic will possibly be required to determine the correct behaviour. Defaults to `false`.
+
 
 ## API
 

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -15,5 +15,6 @@ test('drake has sensible default options', function (t) {
   t.equal(options.removeOnSpill, false, 'options.removeOnSpill defaults to false');
   t.equal(options.direction, 'vertical', 'options.direction defaults to \'vertical\'');
   t.equal(options.mirrorContainer, document.body, 'options.mirrorContainer defaults to an document.body');
+  t.equal(options.allowNestedContainers, false, 'options.allowNestedContainers defaults to false');
   t.end();
 });


### PR DESCRIPTION
Adds the 'allowNestedContainers' option so as to give the ability to allow dragging of nested containers, rather than just blocking it straight away. Updated the readme.