### PR TITLE
add pixel threshold as option

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -27,6 +27,7 @@ function dragula (initialContainers, options) {
   var _grabbed; // holds mousedown context until first mousemove
 
   var o = options || {};
+  if (o.pixelThreshold === void 0) { o.pixelThreshold = 0; }
   if (o.moves === void 0) { o.moves = always; }
   if (o.accepts === void 0) { o.accepts = always; }
   if (o.invalid === void 0) { o.invalid = invalidTarget; }
@@ -362,6 +363,10 @@ function dragula (initialContainers, options) {
     var clientY = getCoord('clientY', e);
     var x = clientX - _offsetX;
     var y = clientY - _offsetY;
+
+    if (_moveX - clientX < o.pixelThreshold && _moveY - clientY < o.pixelThreshold) {
+      return;
+    }
 
     _mirror.style.left = x + 'px';
     _mirror.style.top = y + 'px';

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -6,6 +6,7 @@ var dragula = require('..');
 test('drake has sensible default options', function (t) {
   var options = {};
   dragula(options);
+  t.equal(options.pixelThreshold, 0, 'options.pixelThreshold defaults to 0');
   t.equal(typeof options.moves, 'function', 'options.moves defaults to a method');
   t.equal(typeof options.accepts, 'function', 'options.accepts defaults to a method');
   t.equal(typeof options.invalid, 'function', 'options.invalid defaults to a method');


### PR DESCRIPTION
Per #259, a lot of users don't click exactly on draggable elements and thus inadvertently kick off the drag. This PR adds a pixel threshold (defaulted to 0 pixels to match the current behavior) that will prevent the drag behaviors from starting until the threshold is exceeded.

Note: From my limited user testing, it seems a good threshold for most users is around `10px`.

I couldn't find any tests that verify the current `clientX`/`clientY` drag logic, but I'd feel a lot more comfortable if this PR had a few tests verifying the behavior (both for the default and for the new functionality). Anyone have any thoughts on the best way to handle this?