### PR TITLE
Fix attept to remove already removed node

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -285,7 +285,7 @@ function dragula (initialContainers, options) {
     var parent = getParent(item);
     var initial = isInitialPlacement(parent);
     if (initial === false && reverts) {
-      if (_copy) {
+      if (parent && _copy) {
         parent.removeChild(_copy);
       } else {
         _source.insertBefore(item, _initialSibling);


### PR DESCRIPTION
I have a drake like this:
```
{
  revertOnSpill: true,
  copy: function(el, source) {
     return source.className === 'enable-copy';
   }
 }
```
When I drag an item with class `enable-copy` and I drop it outside any container (to cancel dragging) I am getting this error

```
TypeError: Cannot read property 'removeChild' of null
    at cancel (dragula.js:289)
    at HTMLHtmlElement.release (dragula.js:249)
```

This results bad in behaviour, when user is forced to drop an item into container

This happens, because, dragula is trying to remove `gu-transit` classed item which is no longer in DOM and thus has null parent.

This pull requrest fixed the issue for me.