### PR TITLE
added options.mirror

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -39,6 +39,7 @@ function dragula (initialContainers, options) {
   if (o.direction === void 0) { o.direction = 'vertical'; }
   if (o.ignoreInputTextSelection === void 0) { o.ignoreInputTextSelection = true; }
   if (o.mirrorContainer === void 0) { o.mirrorContainer = doc.body; }
+  if (o.mirror === void 0) { o.mirror = cloneItem; }
 
   var drake = emitter({
     containers: o.containers,
@@ -421,10 +422,7 @@ function dragula (initialContainers, options) {
     if (_mirror) {
       return;
     }
-    var rect = _item.getBoundingClientRect();
-    _mirror = _item.cloneNode(true);
-    _mirror.style.width = getRectWidth(rect) + 'px';
-    _mirror.style.height = getRectHeight(rect) + 'px';
+    _mirror = o.mirror(_item, _offsetX, _offsetY);
     classes.rm(_mirror, 'gu-transit');
     classes.add(_mirror, 'gu-mirror');
     o.mirrorContainer.appendChild(_mirror);
@@ -556,6 +554,13 @@ function getElementBehindPoint (point, x, y) {
 
 function never () { return false; }
 function always () { return true; }
+function cloneItem (item) {
+  var rect = item.getBoundingClientRect();
+  var mirror = item.cloneNode(true);
+  mirror.style.width = getRectWidth(rect) + 'px';
+  mirror.style.height = getRectHeight(rect) + 'px';
+  return mirror;
+}
 function getRectWidth (rect) { return rect.width || (rect.right - rect.left); }
 function getRectHeight (rect) { return rect.height || (rect.bottom - rect.top); }
 function getParent (el) { return el.parentNode === doc ? null : el.parentNode; }

--- a/readme.markdown
+++ b/readme.markdown
@@ -101,6 +101,13 @@ dragula(containers, {
   invalid: function (el, handle) {
     return false; // don't prevent any drags from initiating by default
   },
+  mirror: function (el, offsetX, offsetY) {
+    var rect = el.getBoundingClientRect();
+    var mirror = el.cloneNode(true);
+    mirror.style.width = getRectWidth(rect) + 'px';
+    mirror.style.height = getRectHeight(rect) + 'px';
+    return mirror; // clones `el` and places it relatively to mouse click
+  },
   direction: 'vertical',             // Y axis is considered when determining where an element would be dropped
   copy: false,                       // elements are moved by default, not copied
   copySortSource: false,             // elements in copy-source containers can be reordered
@@ -220,6 +227,12 @@ invalid: function (el, handle) {
   return el.tagName === 'A';
 }
 ```
+
+#### `options.mirror`
+
+You can provide a custom `mirror` method with a `(el, offsetX, offsetY)` signature. This method should return a `HTMLElement` to be shown while dragging the clicked `el` element. You can use `offsetX` and `offsetY` to position your custom mirror relatively to the point where cursor clicked `el`.
+
+The default behavior of this method (if not provided) is cloning `el` and positioning it relatively to the mouse click.
 
 #### `options.mirrorContainer`
 


### PR DESCRIPTION
This PR provides a new feature: custom mirrors can be now provided through `options.mirror`.

The `options.mirror` method is called with three arguments:

- `el`: the clicked item.
- `offsetX`: the horizontal relative position of the cursor from the top left corner of `el`.
- `offsetY`: the vertical relative position of the cursor from the top left corner of `el`.

The original code that cloned `el` has been extracted into a separate function `cloneItem`, and this is the default behavior if `options.mirror` is not provided.