### PR TITLE
added options.noShadow

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -39,6 +39,7 @@ function dragula (initialContainers, options) {
   if (o.direction === void 0) { o.direction = 'vertical'; }
   if (o.ignoreInputTextSelection === void 0) { o.ignoreInputTextSelection = true; }
   if (o.mirrorContainer === void 0) { o.mirrorContainer = doc.body; }
+  if (o.noShadow === void 0) { o.noShadow = false; }
 
   var drake = emitter({
     containers: o.containers,
@@ -242,7 +243,7 @@ function dragula (initialContainers, options) {
     var elementBehindCursor = getElementBehindPoint(_mirror, clientX, clientY);
     var dropTarget = findDropTarget(elementBehindCursor, clientX, clientY);
     if (dropTarget && ((_copy && o.copySortSource) || (!_copy || dropTarget !== _source))) {
-      drop(item, dropTarget);
+      drop(item, dropTarget, e);
     } else if (o.removeOnSpill) {
       remove();
     } else {
@@ -250,7 +251,7 @@ function dragula (initialContainers, options) {
     }
   }
 
-  function drop (item, target) {
+  function drop (item, target, event) {
     var parent = getParent(item);
     if (_copy && o.copySortSource && target === _source) {
       parent.removeChild(_item);
@@ -258,7 +259,7 @@ function dragula (initialContainers, options) {
     if (isInitialPlacement(target)) {
       drake.emit('cancel', item, _source, _source);
     } else {
-      drake.emit('drop', item, target, _source, _currentSibling);
+      drake.emit('drop', item, target, _source, _currentSibling, event);
     }
     cleanup();
   }
@@ -382,6 +383,11 @@ function dragula (initialContainers, options) {
       }
       return;
     }
+
+    if (o.noShadow) {
+      return;
+    }
+
     var reference;
     var immediate = getImmediateChild(dropTarget, elementBehindCursor);
     if (immediate !== null) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -108,6 +108,7 @@ dragula(containers, {
   removeOnSpill: false,              // spilling will `.remove` the element, if this is true
   mirrorContainer: document.body,    // set the element that gets mirror elements appended
   ignoreInputTextSelection: true     // allows users to select input text, see details below
+  noShadow: false                    // no visual aid shadow is used
 });
 ```
 
@@ -231,6 +232,12 @@ When this option is enabled, if the user clicks on an input element the drag won
 
 This option is enabled by default. Turn it off by setting it to `false`. If its disabled your users won't be able to select text in inputs within `dragula` containers with their mouse.
 
+#### `options.noShadow`
+
+When this option is enabled, no visual aid shadow is used, and the dragged element (the copy if `options.copy = true` or the original element otherwise) is **not automatically dropped** in the target. This is useful if you want to customize the element insertion in elements such `svg` or `canvas`.
+
+This option speeds things up because the DOM operations decrease significantly.
+
 ## API
 
 The `dragula` method returns a tiny object with a concise API. We'll refer to the API returned by `dragula` as `drake`.
@@ -272,7 +279,7 @@ Event Name | Listener Arguments               | Event Description
 -----------|----------------------------------|-------------------------------------------------------------------------------------
 `drag`     | `el, source`                     | `el` was lifted from `source`
 `dragend`  | `el`                             | Dragging event for `el` ended with either `cancel`, `remove`, or `drop`
-`drop`     | `el, target, source, sibling`    | `el` was dropped into `target` before a `sibling` element, and originally came from `source`
+`drop`     | `el, target, source, sibling, event`    | `el` was dropped into `target` before a `sibling` element at position given by `event`, and originally came from `source`
 `cancel`   | `el, container, source`          | `el` was being dragged but it got nowhere and went back into `container`, its last stable parent; `el` originally came from `source`
 `remove`   | `el, container, source`          | `el` was being dragged but it got nowhere and it was removed from the DOM. Its last stable parent was `container`, and originally came from `source`
 `shadow`   | `el, container, source`          | `el`, _the visual aid shadow_, was moved into `container`. May trigger many times as the position of `el` changes, even within the same `container`; `el` originally came from `source`


### PR DESCRIPTION
This PR provides a new feature: avoid use of visual aid shadow through `options.noShadow`.

This feature is specially useful when the target is `svg` or `canvas`, where you want to draw a new element instead of inserting it before/after a node under the parent.

The PR avoids all the DOM insertions/deletions related to the shadow processing, improving the performance of `dragula`. The `drop` JavaScript event is passed as parameter to the `drop` event. This way the user can place/draw the new element at the exact coordinates of dropping.