### PR TITLE
Add powerful example in github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ dragula([document.getElementById(left), document.getElementById(right)], {
       <code>
 dragula([document.getElementById(left), document.getElementById(right)], {
   moves: function (el, container, handle) {
-    return handle.className === 'handle';
+    return handle.classList.contains('handle');
   }
 });
       </code>


### PR DESCRIPTION
In the case where your cruise element has multiple classes `handle.className === 'handle'` doesn't do the work.

The hyper-compatible `indexOf` do that. So i've added one more example.