### PR TITLE
Add 'mixed' direction option

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -457,6 +457,7 @@ function dragula (initialContainers, options) {
 
   function getReference (dropTarget, target, x, y) {
     var horizontal = o.direction === 'horizontal';
+    var mixed = o.direction === 'mixed';
     var reference = target !== dropTarget ? inside() : outside();
     return reference;
 
@@ -469,13 +470,22 @@ function dragula (initialContainers, options) {
         el = dropTarget.children[i];
         rect = el.getBoundingClientRect();
         if (horizontal && (rect.left + rect.width / 2) > x) { return el; }
-        if (!horizontal && (rect.top + rect.height / 2) > y) { return el; }
+        if (!mixed && !horizontal && (rect.top + rect.height / 2) > y) { return el; }
+        if (mixed && (rect.left + rect.width) > x && (rect.top + rect.height) > y) { return el; }
       }
       return null;
     }
 
     function inside () { // faster, but only available if dropped inside a child element
       var rect = target.getBoundingClientRect();
+      if (mixed) {
+        var distToTop = y - rect.top;
+        var distToLeft = x - rect.left;
+        var distToBottom = rect.bottom - y;
+        var distToRight = rect.right - x;
+        var minDist = Math.min(distToLeft, distToRight, distToTop, distToBottom);
+        return resolve(distToLeft === minDist || distToTop === minDist);
+      }
       if (horizontal) {
         return resolve(x > rect.left + getRectWidth(rect) / 2);
       }

--- a/readme.markdown
+++ b/readme.markdown
@@ -199,7 +199,7 @@ By default, spilling an element outside of any containers will move the element 
 
 #### `options.direction`
 
-When an element is dropped onto a container, it'll be placed near the point where the mouse was released. If the `direction` is `'vertical'`, the default value, the Y axis will be considered. Otherwise, if the `direction` is `'horizontal'`, the X axis will be considered.
+When an element is dropped onto a container, it'll be placed near the point where the mouse was released. If the `direction` is `'vertical'`, the default value, the Y axis will be considered. If the `direction` is `'horizontal'`, the X axis will be considered, and if it's `'mixed'` both axes will be considered.
 
 #### `options.invalid`
 


### PR DESCRIPTION
Based on PR #315 by @ojensen5115, adds a `'mixed'` direction that works better than `'horizontal'` or `'vertical'` when the container wraps elements over multiple rows.