### PR TITLE
Passing the DOM event to subscribers

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -242,28 +242,28 @@ function dragula (initialContainers, options) {
     var elementBehindCursor = getElementBehindPoint(_mirror, clientX, clientY);
     var dropTarget = findDropTarget(elementBehindCursor, clientX, clientY);
     if (dropTarget && ((_copy && o.copySortSource) || (!_copy || dropTarget !== _source))) {
-      drop(item, dropTarget);
+      drop(item, dropTarget, e);
     } else if (o.removeOnSpill) {
-      remove();
+      remove(e);
     } else {
-      cancel();
+      cancel(e);
     }
   }
 
-  function drop (item, target) {
+  function drop (item, target, e) {
     var parent = getParent(item);
     if (_copy && o.copySortSource && target === _source) {
       parent.removeChild(_item);
     }
     if (isInitialPlacement(target)) {
-      drake.emit('cancel', item, _source, _source);
+      drake.emit('cancel', item, _source, _source, undefined, e);
     } else {
-      drake.emit('drop', item, target, _source, _currentSibling);
+      drake.emit('drop', item, target, _source, _currentSibling, e);
     }
     cleanup();
   }
 
-  function remove () {
+  function remove (e) {
     if (!drake.dragging) {
       return;
     }
@@ -272,11 +272,11 @@ function dragula (initialContainers, options) {
     if (parent) {
       parent.removeChild(item);
     }
-    drake.emit(_copy ? 'cancel' : 'remove', item, parent, _source);
+    drake.emit(_copy ? 'cancel' : 'remove', item, parent, _source, e);
     cleanup();
   }
 
-  function cancel (revert) {
+  function cancel (revert, e) {
     if (!drake.dragging) {
       return;
     }
@@ -294,9 +294,9 @@ function dragula (initialContainers, options) {
       }
     }
     if (initial || reverts) {
-      drake.emit('cancel', item, _source, _source);
+      drake.emit('cancel', item, _source, _source, undefined, e);
     } else {
-      drake.emit('drop', item, parent, _source, _currentSibling);
+      drake.emit('drop', item, parent, _source, _currentSibling, e);
     }
     cleanup();
   }


### PR DESCRIPTION
I was using dragula but I found that I needed to get a reference to the DOM element that the item was dropped on. I couldn't find a way to do this with the existing API so I added the event to the drake emits and was able to develop the feature on my app that I couldn't before. I thought others might want this feature too so I'm putting in this PR. Please let me know if anything else would be required to merge this.