### PR TITLE
Fix preventing scroll in latest browsers

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -513,8 +513,8 @@ function touchy (el, op, type, fn) {
   } else if (global.navigator.msPointerEnabled) {
     crossvent[op](el, microsoft[type], fn);
   } else {
-    crossvent[op](el, touch[type], fn);
-    crossvent[op](el, type, fn);
+    crossvent[op](el, touch[type], fn, { passive: false });
+    crossvent[op](el, type, fn, { passive: false });
   }
 }
 


### PR DESCRIPTION
To optimize scrolling in touch devices, at least Chrome has now enabled by default the `passive` option for addEventListener.

See https://www.chromestatus.com/features/5093566007214080.

Simply passing `{ passive: false }` to `crossvent` on touch event solves this issue.

This fixes #468.