### PR TITLE
Fix #456

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -419,12 +419,22 @@ function dragula (initialContainers, options) {
     if (drake.dragging) { classes.add(el, 'gu-hide'); }
   }
 
+  function cloneElement (el) {
+    var selector = 'select';  // more types can be added later
+    var clone = el.cloneNode(true); // This does not copy certain values, e.g. select values
+    var cloneDescendants = clone.querySelectorAll(selector);
+    el.querySelectorAll(selector).forEach(function (element, i) {
+        cloneDescendants[i].value = element.value;
+    });
+    return clone;
+  }
+
   function renderMirrorImage () {
     if (_mirror) {
       return;
     }
     var rect = _item.getBoundingClientRect();
-    _mirror = _item.cloneNode(true);
+    _mirror = cloneElement(_item); // fixes https://github.com/bevacqua/dragula/issues/456
     _mirror.style.width = getRectWidth(rect) + 'px';
     _mirror.style.height = getRectHeight(rect) + 'px';
     classes.rm(_mirror, 'gu-transit');

--- a/test/drag.js
+++ b/test/drag.js
@@ -163,18 +163,25 @@ test('when dragging, body gets gu-unselectable class', function (t) {
 test('when dragging, element gets a mirror image for show', function (t) {
   var div = document.createElement('div');
   var item = document.createElement('div');
+  var select = document.createElement('select');
   var drake = dragula([div]);
   item.innerHTML = '<em>the force is <strong>with this one</strong></em>';
+  select.innerHTML = '<option>item1</option><option>item2</option>';
+  select.value = 'item2';
+  item.appendChild(select);
   div.appendChild(item);
   document.body.appendChild(div);
   drake.on('cloned', cloned);
   events.raise(item, 'mousedown', { which: 1 });
   events.raise(item, 'mousemove', { which: 1 });
-  t.plan(4);
+  t.plan(5);
   t.end();
   function cloned (mirror, target) {
     t.equal(item.className, 'gu-transit', 'item does not have gu-mirror class');
     t.equal(mirror.className, 'gu-mirror', 'mirror only has gu-mirror class');
+    var mirrorValue = mirror.querySelectorAll('select')[0].value;
+    var itemValue = item.querySelectorAll('select')[0].value;
+    t.equal(mirrorValue, itemValue, 'mirror has the right select values');
     t.equal(mirror.innerHTML, item.innerHTML, 'mirror is passed to \'cloned\' event');
     t.equal(target, item, 'cloned lets you know that the mirror is a clone of `item`');
   }


### PR DESCRIPTION
Fixes #456 by introducing a clone function that also copies select values instead of using cloneNode(true).