### PR TITLE
Add optional drag delay

### DIFF
--- a/dist/dragula.js
+++ b/dist/dragula.js
@@ -62,6 +62,7 @@ function dragula (initialContainers, options) {
   var _renderTimer; // timer for setTimeout renderMirrorImage
   var _lastDropTarget = null; // last container item was over
   var _grabbed; // holds mousedown context until first mousemove
+  var _grabbedTime; // holds mousedown timestamp so we can allow for delay
 
   var o = options || {};
   if (o.moves === void 0) { o.moves = always; }
@@ -76,6 +77,7 @@ function dragula (initialContainers, options) {
   if (o.direction === void 0) { o.direction = 'vertical'; }
   if (o.ignoreInputTextSelection === void 0) { o.ignoreInputTextSelection = true; }
   if (o.mirrorContainer === void 0) { o.mirrorContainer = doc.body; }
+  if (o.dragDelay === void 0) { o.dragDelay = 0; }
 
   var drake = emitter({
     containers: o.containers,
@@ -142,6 +144,7 @@ function dragula (initialContainers, options) {
       return;
     }
     _grabbed = context;
+    _grabbedTime = Date.now();
     eventualMovements();
     if (e.type === 'mousedown') {
       if (isInput(item)) { // see also: https://github.com/bevacqua/dragula/issues/208
@@ -171,6 +174,10 @@ function dragula (initialContainers, options) {
       if (isInput(elementBehindCursor)) {
         return;
       }
+    }
+    // allow for minimum grab delay
+    if (_grabbedTime + o.dragDelay > Date.now()){
+      return;
     }
 
     var grabbed = _grabbed; // call to end() unsets _grabbed

--- a/readme.markdown
+++ b/readme.markdown
@@ -107,7 +107,8 @@ dragula(containers, {
   revertOnSpill: false,              // spilling will put the element back where it was dragged from, if this is true
   removeOnSpill: false,              // spilling will `.remove` the element, if this is true
   mirrorContainer: document.body,    // set the element that gets mirror elements appended
-  ignoreInputTextSelection: true     // allows users to select input text, see details below
+  ignoreInputTextSelection: true,    // allows users to select input text, see details below
+  dragDelay: 0                       // require click to be held for a certain delay before dragging
 });
 ```
 
@@ -230,6 +231,10 @@ The DOM element where the mirror element displayed while dragging will be append
 When this option is enabled, if the user clicks on an input element the drag won't start until their mouse pointer exits the input. This translates into the user being able to select text in inputs contained inside draggable elements, and still drag the element by moving their mouse outside of the input -- so you get the best of both worlds.
 
 This option is enabled by default. Turn it off by setting it to `false`. If its disabled your users won't be able to select text in inputs within `dragula` containers with their mouse.
+
+#### `options.dragDelay`
+
+You can set a delay time (in milliseconds) from the time the user clicks an item until moving the mouse will start a drag.  If your elements double as both draggable and clickable this option can help safeguard against accidentally dragging when the user meant to click.  Defaults to 0ms (drag can start immediately).
 
 ## API
 


### PR DESCRIPTION
Adds an option to introduce a delay between the mouseDown event and when mouse movement triggers a drag.  I'm submitting this pull request because in our web application my boss keeps accidentally dragging items when intending to click on them.