### PR TITLE
Changes the button detect mechanism in function whichMouseButton.

### DIFF
--- a/dist/dragula.js
+++ b/dist/dragula.js
@@ -556,13 +556,15 @@ function touchy (el, op, type, fn) {
 }
 
 function whichMouseButton (e) {
-  if (e.touches !== void 0) { return e.touches.length; }
-  if (e.which !== void 0 && e.which !== 0) { return e.which; } // see https://github.com/bevacqua/dragula/issues/261
-  if (e.buttons !== void 0) { return e.buttons; }
-  var button = e.button;
-  if (button !== void 0) { // see https://github.com/jquery/jquery/blob/99e8ff1baa7ae341e94bb89c3e84570c7c3ad9ea/src/event.js#L573-L575
-    return button & 1 ? 1 : button & 2 ? 3 : (button & 4 ? 2 : 0);
-  }
+   if (e.touches) { return e.touches.length; }
+	    if (e.originalEvent && e.originalEvent.touches) { return e.originalEvent.touches.length; }
+	    if (e.which !== void 0 && e.which !== 0) { return e.which; } // github.com/bevacqua/dragula/issues/261
+	    var button = e.button;
+	    if (button !== undefined) { // see github.com/jquery/jquery/blob/99e8ff1baa7ae341e94bb89c3e84570c7c3ad9ea/src/event.js#L573-L575
+	      // button == 0?1:** for the e object was unwrapped orginalEvent object in jQuery enviroment.
+	      return button==0?1:button & 1 ? 1 : button & 2 ? 3 : (button & 4 ? 2 : 0);
+	    }
+	    if (e.buttons !== undefined) { return e.buttons; }
 }
 
 function getOffset (el) {

--- a/dragula.js
+++ b/dragula.js
@@ -519,13 +519,15 @@ function touchy (el, op, type, fn) {
 }
 
 function whichMouseButton (e) {
-  if (e.touches !== void 0) { return e.touches.length; }
-  if (e.which !== void 0 && e.which !== 0) { return e.which; } // see https://github.com/bevacqua/dragula/issues/261
-  if (e.buttons !== void 0) { return e.buttons; }
-  var button = e.button;
-  if (button !== void 0) { // see https://github.com/jquery/jquery/blob/99e8ff1baa7ae341e94bb89c3e84570c7c3ad9ea/src/event.js#L573-L575
-    return button & 1 ? 1 : button & 2 ? 3 : (button & 4 ? 2 : 0);
-  }
+   if (e.touches) { return e.touches.length; }
+	 if (e.originalEvent && e.originalEvent.touches) { return e.originalEvent.touches.length; }
+	 if (e.which !== void 0 && e.which !== 0) { return e.which; } // github.com/bevacqua/dragula/issues/261
+	 var button = e.button;
+	 if (button !== undefined) { // see github.com/jquery/jquery/blob/99e8ff1baa7ae341e94bb89c3e84570c7c3ad9ea/src/event.js#L573-L575
+	   // button == 0?1:** for the e object was unwrapped orginalEvent object in jQuery enviroment.
+	   return button==0?1:button & 1 ? 1 : button & 2 ? 3 : (button & 4 ? 2 : 0);
+	 }
+	 if (e.buttons !== undefined) { return e.buttons; }
 }
 
 function getOffset (el) {


### PR DESCRIPTION
dragula is so great the lost of the libs refers. However some logic just drive me crazy, such as the button detect mechanism in function whichMouseButton. I found it at dragular and that make things not work at chrome ( 63.0.3239.84 64bit mac) & crosswalk 19+,so provides a change and thing goes will. However, today, few months later, I found that issue exits at another lib "ng2-dragular" and cause the same impacts, so maybe more libs would just refer dragula and may faces the same "problem".
Plz refer this discuss before and accept my pull request. 

https://github.com/luckylooke/dragular/issues/125

Thx & Great Job