### PR TITLE
Respect non-element node original positions when reverting on cancel

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -19,6 +19,7 @@ function dragula (initialContainers, options) {
   var _offsetY; // reference y
   var _moveX; // reference move x
   var _moveY; // reference move y
+  var _initialSiblingNode; // reference sibling node when grabbed
   var _initialSibling; // reference sibling when grabbed
   var _currentSibling; // reference sibling now
   var _copy; // item used for copying
@@ -206,6 +207,7 @@ function dragula (initialContainers, options) {
 
     _source = context.source;
     _item = context.item;
+    _initialSiblingNode = context.item.nextSibling;
     _initialSibling = _currentSibling = nextEl(context.item);
 
     drake.dragging = true;
@@ -284,14 +286,10 @@ function dragula (initialContainers, options) {
     var item = _copy || _item;
     var parent = getParent(item);
     var initial = isInitialPlacement(parent);
-    if (initial === false && reverts) {
-      if (_copy) {
-        if (parent) {
-          parent.removeChild(_copy);
-        }
-      } else {
-        _source.insertBefore(item, _initialSibling);
-      }
+    if (initial === false && reverts && _copy && parent) {
+      parent.removeChild(_copy);
+    } else if (reverts && !_copy) {
+      _source.insertBefore(item, _initialSiblingNode);
     }
     if (initial || reverts) {
       drake.emit('cancel', item, _source, _source);
@@ -316,7 +314,7 @@ function dragula (initialContainers, options) {
       drake.emit('out', item, _lastDropTarget, _source);
     }
     drake.emit('dragend', item);
-    _source = _item = _copy = _initialSibling = _currentSibling = _renderTimer = _lastDropTarget = null;
+    _source = _item = _copy = _initialSiblingNode = _initialSibling = _currentSibling = _renderTimer = _lastDropTarget = null;
   }
 
   function isInitialPlacement (target, s) {


### PR DESCRIPTION
Fixes #550. All tests pass.

* Before: https://codepen.io/anon/pen/ZrXJwd/
* After: https://codepen.io/anon/pen/ZrXXPB/

Try dragging "CCC" item below the list. Before this fix, the element gets returned to the end of the container, disregarding the fact that there were non-element nodes after it on drag start. After the fix, it gets returned to its proper position.

I tried writing a test for this issue, but I couldn't figure how to simulate actually dragging elements around, and that's required to trigger the bug. I couldn't find any tests that did dragging (AFAICT). If someone can point me to a test that actually drags elements around, I'll have a look at it and write the test.

Ideally, non-element nodes should be respected while dragging as well, but that might be a bit more difficult (just a bit, I think). I'll give that a shot if I see positive response to this PR.

Thanks!