### PR TITLE
fix: allow calling release without argument

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -82,7 +82,7 @@ function dragula (initialContainers, options) {
 
   function destroy () {
     events(true);
-    release({});
+    release();
   }
 
   function preventGrabbed (e) {
@@ -120,7 +120,7 @@ function dragula (initialContainers, options) {
       return;
     }
     if (whichMouseButton(e) === 0) {
-      release({});
+      release();
       return; // when text is selected on an input and then dragged, mouseup doesn't fire. this is our only hope
     }
     // truthy check fixes #239, equality fixes #207
@@ -236,11 +236,14 @@ function dragula (initialContainers, options) {
     if (!drake.dragging) {
       return;
     }
+    var dropTarget;
     var item = _copy || _item;
-    var clientX = getCoord('clientX', e);
-    var clientY = getCoord('clientY', e);
-    var elementBehindCursor = getElementBehindPoint(_mirror, clientX, clientY);
-    var dropTarget = findDropTarget(elementBehindCursor, clientX, clientY);
+    if (e) {
+      var clientX = getCoord('clientX', e);
+      var clientY = getCoord('clientY', e);
+      var elementBehindCursor = getElementBehindPoint(_mirror, clientX, clientY);
+      dropTarget = findDropTarget(elementBehindCursor, clientX, clientY);
+    }
     if (dropTarget && ((_copy && o.copySortSource) || (!_copy || dropTarget !== _source))) {
       drop(item, dropTarget);
     } else if (o.removeOnSpill) {


### PR DESCRIPTION
Calling `release({})` used to be okay. The code of `release` would try to grab `clientX/Y` from the empty object, get `undefined` for both coordinate, and feed them to `elementFromPoint`. `elementFromPoint` was fine with that and just returned `null`. However a recent Chrome change broke this. Chrome now checks that the coordinates passed to `elementFromPoint` are finite doubles and so passing `undefined` no longer works.

This commit makes it so that calling release without an event object works. It will just skip trying to find a drop target.

As I was submitting this PR, I noticed another [PR](https://github.com/bevacqua/dragula/pull/552) for the same issue. However, I disagree with the solution provided there. Calling `release` with `clientX` and `clientY` arbitrarily set to -1 is not safe as the coordinates `-1, -1` can be pointing to a legitimate element for some use-case scenarios. Rare? Yes, but it can happen.