### PR TITLE
Mirror image issues

### DIFF
--- a/dist/dragula.js
+++ b/dist/dragula.js
@@ -466,17 +466,25 @@ function dragula (initialContainers, options) {
     _mirror.style.height = getRectHeight(rect) + 'px';
     classes.rm(_mirror, 'gu-transit');
     classes.add(_mirror, 'gu-mirror');
-    o.mirrorContainer.appendChild(_mirror);
-    touchy(documentElement, 'add', 'mousemove', drag);
-    classes.add(o.mirrorContainer, 'gu-unselectable');
-    drake.emit('cloned', _mirror, _item, 'mirror');
+    var _existingMirror = document.querySelector('.gu-mirror');
+    if(_existingMirror === null)
+    {
+        console.log('incoming mirror');
+        console.log(_mirror);
+        o.mirrorContainer.append(_mirror);
+        touchy(documentElement, 'add', 'mousemove', drag);
+        classes.add(o.mirrorContainer, 'gu-unselectable');
+        drake.emit('cloned', _mirror, _item, 'mirror');
+    }
   }
 
   function removeMirrorImage () {
     if (_mirror) {
       classes.rm(o.mirrorContainer, 'gu-unselectable');
       touchy(documentElement, 'remove', 'mousemove', drag);
-      getParent(_mirror).removeChild(_mirror);
+      console.log('incoming parent');
+      console.log(getParent(_mirror));
+      getParent(_mirror) !== null ? getParent(_mirror).removeChild(_mirror) : null;
       _mirror = null;
     }
   }


### PR DESCRIPTION
Fixed a performance issue occurring when dragging an element that contains child elements. A mirror image was being created for each child image as well as the containing element. This lead to performance issues when starting to drag and waiting for elements to settle, so that the element could be dropped. This fix just checks if a mirror image already exists, and if so, doesn't append another one.