### PR TITLE
Adjust isInput logic

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -564,7 +564,7 @@ function always () { return true; }
 function getRectWidth (rect) { return rect.width || (rect.right - rect.left); }
 function getRectHeight (rect) { return rect.height || (rect.bottom - rect.top); }
 function getParent (el) { return el.parentNode === doc ? null : el.parentNode; }
-function isInput (el) { return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || isEditable(el); }
+function isInput (el) { return el.disabled !== void 0 && el.name !== void 0 || isEditable(el); }
 function isEditable (el) {
   if (!el) { return false; } // no parents were editable
   if (el.contentEditable === 'false') { return false; } // stop the lookup


### PR DESCRIPTION
Allows custom input elements to be detected as inputs.

I'm using a [custom input element](https://shoelace.style/components/input?id=input) in a draggable container, and I'm not able to focus it with a mouse because the logic for detecting if an element is an input checks for tag names. I changed to code to use a heuristic instead. Any reasonable input element should have a `name` and `disabled` attribute.