### PR TITLE
fix(sec): upgrade uglify-js to 3.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tap-dev-tool": "1.3.0",
     "tape": "5.0.1",
     "tape-run": "8.0.0",
-    "uglify-js": "3.11.0",
+    "uglify-js": "3.14.3",
     "watchify": "3.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,10 +4870,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-js@3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.0.tgz#67317658d76c21e0e54d3224aee2df4ee6c3e1dc"
-  integrity sha512-e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==
+uglify-js@3.14.3:
+  version "3.14.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.3.tgz#c0f25dfea1e8e5323eccf59610be08b6043c15cf"
+  integrity sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==
 
 umd@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in uglify-js 3.11.0
- [MPS-2022-14112](https://www.oscs1024.com/hd/MPS-2022-14112)


### What did I do？
Upgrade uglify-js from 3.11.0 to 3.14.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>